### PR TITLE
Remove retry & backoff mechanism

### DIFF
--- a/lib/aftership/v4/base.rb
+++ b/lib/aftership/v4/base.rb
@@ -8,85 +8,54 @@ module AfterShip
       end
       attr_reader :http_verb_method, :end_point, :query, :body
 
-      MAX_TRIAL = 3
-      CALL_SLEEP = 3
-
       def initialize(http_verb_method, end_point, query = {}, body = {})
         @http_verb_method = http_verb_method
         @end_point = end_point
         @query = query
         @body = body
-        @trial = 0
 
         @client = HTTPClient.new
       end
 
       def call
-
         header = {'aftership-api-key' => AfterShip.api_key, 'Content-Type' => 'application/json'}
 
         parameters = {
-            :query => query,
-            :body => body.to_json,
-            :header => header
+          :query => query,
+          :body => body.to_json,
+          :header => header
         }
 
         cf_ray = ''
-        response = nil
 
-        loop do
-          response = @client.send(http_verb_method, url, parameters)
+        response = @client.send(http_verb_method, url, parameters)
 
-          if response.headers
-            cf_ray = response.headers['CF-RAY']
-          end
-
-
-          if response.body
-            begin
-              response = JSON.parse(response.body)
-              @trial = MAX_TRIAL + 1
-            rescue
-              @trial += 1
-
-              sleep CALL_SLEEP
-
-              response = {
-                  :meta => {
-                      :code => 500,
-                      :message => 'Something went wrong on AfterShip\'s end.',
-                      :type => 'InternalError'
-                  },
-                  :data => {
-                      :body => response.body,
-                      :cf_ray => cf_ray
-                  }
-              }
-            end
-          else
-            response = {
-                :meta => {
-                    :code => 500,
-                    :message => 'Something went wrong on AfterShip\'s end.',
-                    :type => 'InternalError'
-                },
-                :data => {
-                }
-            }
-          end
-
-          break if @trial > MAX_TRIAL
+        if response.headers
+          cf_ray = response.headers['CF-RAY']
         end
 
-        response
+        if response.body
+          response = JSON.parse(response.body)
+        else
+          response = {
+            :meta => {
+              :code => 500,
+              :message => 'Something went wrong on AfterShip\'s end.',
+              :type => 'InternalError'
+            },
+            :data => {
+            }
+          }
+        end
       end
 
-      private
+      response
+    end
 
-      def url
-        "#{AfterShip::URL}/v4/#{end_point.to_s}"
-      end
+    private
 
+    def url
+      "#{AfterShip::URL}/v4/#{end_point.to_s}"
     end
   end
 end


### PR DESCRIPTION
The current retry mechanism uses `sleep`, which sleeps the application server's workers for certain amount of time (in this case 3 seconds). In high-traffic environments an application that uses the gem can essentially get flooded with incoming requests because while the worker is `sleep`ing while a massive amount of requests can pile up in the queue, essentially DoSing the server.

We saw this effect recently when Aftership's API [had a degradation of service](https://status.aftership.com/incidents/jxkm3w1w6f40), which caused the gem to `sleep` and retry the requests.

<img width="889" alt="screen shot 2017-12-07 at 11 12 31" src="https://user-images.githubusercontent.com/854173/33710034-95bfe85e-db3f-11e7-9398-eda5f42d27ac.png">

A possible better solution for this would be to introduce a [Circuit Breaker](https://martinfowler.com/bliki/CircuitBreaker.html), or make the gem not care about retries and expect the users of the gem to deal with these things on a need-to basis.

WDYT? 