### PR TITLE
Pass option params to retrack and delete

### DIFF
--- a/lib/aftership/v4/tracking.rb
+++ b/lib/aftership/v4/tracking.rb
@@ -17,19 +17,19 @@ module AfterShip
       end
 
       #POST /trackings/:slug/:tracking_number/retrack
-      def self.retrack(slug, tracking_number)
+      def self.retrack(slug, tracking_number, params = {})
         if slug.empty? || slug.nil? || tracking_number.empty? || tracking_number.nil?
           raise ArgumentError.new('slug and tracking_number are required.')
         end
-        new(:post, "trackings/#{slug}/#{tracking_number}/retrack").call
+        new(:post, "trackings/#{slug}/#{tracking_number}/retrack", params).call
       end
 
       #DELETE /trackings/:slug/:tracking_number
-      def self.delete(slug, tracking_number)
+      def self.delete(slug, tracking_number, params = {})
         if slug.empty? || slug.nil? || tracking_number.empty? || tracking_number.nil?
           raise ArgumentError.new('slug and tracking_number are required.')
         end
-        new(:delete, "trackings/#{slug}/#{tracking_number}").call
+        new(:delete, "trackings/#{slug}/#{tracking_number}", params).call
       end
 
       #DELETE /trackings/:id


### PR DESCRIPTION
Some couriers, such as Royal Mail, require the param `tracking_destination_country` to be set. The gem already supports this for creating trackings, but not for retracking and deleting them, which causes an error:
```
{"meta"=>{"code"=>4009, "message"=>"`tracking_destination_country` is required.", "type"=>"BadRequest"}, "data"=>{}}
```
This pull request adds passing option params (including `tracking_destination_country`) to `retrack` and `delete`, e.g.
```
AfterShip::V4::Tracking.delete('royal-mail', 'ZW924750388GB', tracking_destination_country: 'United Kingdom')
```