### PR TITLE
Add compatibility for recent versions of Faraday

### DIFF
--- a/aftership.gemspec
+++ b/aftership.gemspec
@@ -15,8 +15,8 @@ Gem::Specification.new do |s|
   s.require_paths = ['lib']
   s.requirements << 'none'
 
-  s.add_dependency 'faraday', '~> 1.0.1'
-  s.add_dependency 'faraday_middleware', '~> 1.0.0'
+  s.add_dependency 'faraday', '~> 1.0', '>= 1.0.1'
+  s.add_dependency 'faraday_middleware', '~> 1.0'
 
   s.add_development_dependency 'pry'
   s.add_development_dependency 'rspec', '~> 2.14.1'


### PR DESCRIPTION
Allow the use of a Faraday version that supports ruby 2.3, while also allowing more recent versions of Faraday.
This will increase repo compatibility and enable the users of this library to follow the suggestion of using its latest version.