### PR TITLE
Update faraday dependency to support faraday 2.x

### DIFF
--- a/aftership.gemspec
+++ b/aftership.gemspec
@@ -5,7 +5,7 @@ Gem::Specification.new do |s|
   s.licenses = ['MIT']
   s.summary = 'Formerly known as aftership_ruby and a wrapper for AfterShip API. Support the latest V3/V4 API'
   s.description = 'Developed for easy integration with AfterShip'
-  s.required_ruby_version = '>= 2.3.0'
+  s.required_ruby_version = '>= 2.6'
 
   s.author = ['AfterShip Limited']
   s.email = ['support@aftership.com']

--- a/aftership.gemspec
+++ b/aftership.gemspec
@@ -15,8 +15,7 @@ Gem::Specification.new do |s|
   s.require_paths = ['lib']
   s.requirements << 'none'
 
-  s.add_dependency 'faraday', '~> 1.0', '>= 1.0.1'
-  s.add_dependency 'faraday_middleware', '~> 1.0'
+  s.add_dependency 'faraday', '>= 2.0.0'
 
   s.add_development_dependency 'pry'
   s.add_development_dependency 'rspec', '~> 2.14.1'

--- a/lib/aftership/v4/base.rb
+++ b/lib/aftership/v4/base.rb
@@ -1,5 +1,4 @@
 require 'faraday'
-require 'faraday_middleware'
 
 module AfterShip
   module V4

--- a/spec/base_v4_spec.rb
+++ b/spec/base_v4_spec.rb
@@ -1,14 +1,14 @@
 require 'spec_helper'
 
 describe AfterShip::V4::Base do
-  let(:http_verb_method) { 'get' }
+  let(:http_verb_method) { :get }
   let(:end_point)        { 'trackings' }
-  let(:params)           { { courier: 'usps' } }
+  let(:query)           { { courier: 'usps' } }
   let(:body)             { { emails: ['me@example.com'] } }
-  subject                { described_class.new(http_verb_method, end_point, params, body) }
+  subject                { described_class.new(http_verb_method, end_point, query, body) }
 
   its(:body)             { should(eq(body)) }
-  its(:params)           { should(eq(params)) }
+  its(:query)           { should(eq(query)) }
   its(:end_point)        { should(eq(end_point)) }
   its(:http_verb_method) { should(eq(http_verb_method)) }
 
@@ -24,7 +24,7 @@ describe AfterShip::V4::Base do
       #HTTPI.logger.should_receive(:warn).with("the emails field should be an array").once
       #HTTPI.logger.should_receive(:warn).with('the smses field should be an array').once
 
-      #HTTPI.should_receive(:send).with(:get, kind_of(HTTPI::Request)).and_return(response)
+      # HTTPI.should_receive(:send).with(:get, kind_of(HTTPI::Request)).and_return(response)
       subject.call
     end
 


### PR DESCRIPTION
### Breaking change

#### New Faraday 2.x:
* `faraday-middleware` has been [deprecated](https://github.com/lostisland/faraday/blob/main/UPGRADING.md#faraday-middleware-deprecation) and it's no longer supported
* The Faraday interface has changed ([upgrade guide](https://github.com/lostisland/faraday/blob/main/UPGRADING.md))

#### Minimum Ruby version
* The minimum Ruby version was changed to align with Faraday's Ruby version requirements

**Note:** While the Faraday interface has changed, this gem does not get affected by those changes. The Faraday middleware that this gem is using is now part of the core Faraday gem, so the gem does not need this dependency anymore. 