### PR TITLE
Fix checks for required values when nil is provided

### DIFF
--- a/lib/aftership/v4/tracking.rb
+++ b/lib/aftership/v4/tracking.rb
@@ -5,7 +5,7 @@ module AfterShip
     class Tracking < AfterShip::V4::Base
       # POST /trackings
       def self.create(tracking_number, params = {})
-        if tracking_number.empty? || tracking_number.nil?
+        if tracking_number.to_s.empty?
           raise ArgumentError, 'tracking_number is required.'
         else
           query_hash = { tracking_number: tracking_number }
@@ -17,7 +17,7 @@ module AfterShip
 
       # POST /trackings/:slug/:tracking_number/retrack
       def self.retrack(slug, tracking_number, params = {})
-        if slug.empty? || slug.nil? || tracking_number.empty? || tracking_number.nil?
+        if slug.to_s.empty? || tracking_number.to_s.empty?
           raise ArgumentError, 'slug and tracking_number are required.'
         end
 
@@ -26,7 +26,7 @@ module AfterShip
 
       # DELETE /trackings/:slug/:tracking_number
       def self.delete(slug, tracking_number, params = {})
-        if slug.empty? || slug.nil? || tracking_number.empty? || tracking_number.nil?
+        if slug.to_s.empty? || tracking_number.to_s.empty?
           raise ArgumentError, 'slug and tracking_number are required.'
         end
 
@@ -35,14 +35,14 @@ module AfterShip
 
       # DELETE /trackings/:id
       def self.delete_by_id(id)
-        raise ArgumentError, 'id is required.' if id.empty? || id.nil?
+        raise ArgumentError, 'id is required.' if id.to_s.empty?
 
         new(:delete, "trackings/#{id}").call
       end
 
       # GET /trackings/:slug/:tracking_number
       def self.get(slug, tracking_number, params = {})
-        if slug.empty? || slug.nil? || tracking_number.empty? || tracking_number.nil?
+        if slug.to_s.empty? || tracking_number.to_s.empty?
           raise ArgumentError, 'slug and tracking_number are required.'
         end
 
@@ -51,7 +51,7 @@ module AfterShip
 
       # GET /trackings/:id
       def self.get_by_id(id, params = {})
-        raise ArgumentError, 'id is required.' if id.empty? || id.nil?
+        raise ArgumentError, 'id is required.' if id.to_s.empty?
 
         new(:get, "trackings/#{id}", params).call
       end
@@ -68,7 +68,7 @@ module AfterShip
 
       # PUT /trackings/:slug/:tracking_number
       def self.update(slug, tracking_number, params = {})
-        if slug.empty? || slug.nil? || tracking_number.empty? || tracking_number.nil?
+        if slug.to_s.empty? || tracking_number.to_s.empty?
           raise ArgumentError, 'slug and tracking_number are required.'
         end
 


### PR DESCRIPTION
This fixes NoMethodError when `nil` value is provided

> undefined method `empty?' for nil:NilClass (NoMethodError)
>
>        if tracking_number.empty? || tracking_number.nil?

Since `nil` doesn't respond to `.empty?` it can not check for `nil?` (and if it did, than it would probably be truthy response).
Instead of switching the order of checks however, I've choose to use a conversion protocol, as the data is expected to be string and used in a string context. `nil.to_s` gives an empty string