### PR TITLE
Fix check for empty method arguments

### DIFF
--- a/lib/aftership/v4/tracking.rb
+++ b/lib/aftership/v4/tracking.rb
@@ -5,19 +5,17 @@ module AfterShip
     class Tracking < AfterShip::V4::Base
       # POST /trackings
       def self.create(tracking_number, params = {})
-        if tracking_number.empty? || tracking_number.nil?
-          raise ArgumentError, 'tracking_number is required.'
-        else
-          query_hash = { tracking_number: tracking_number }
-          query_hash.merge!(params)
-          body = { tracking: query_hash }
-          new(:post, 'trackings', {}, body).call
-        end
+        raise ArgumentError, 'tracking_number is required.' if tracking_number.to_s.empty?
+
+        query_hash = { tracking_number: tracking_number }
+        query_hash.merge!(params)
+        body = { tracking: query_hash }
+        new(:post, 'trackings', {}, body).call
       end
 
       # POST /trackings/:slug/:tracking_number/retrack
       def self.retrack(slug, tracking_number, params = {})
-        if slug.empty? || slug.nil? || tracking_number.empty? || tracking_number.nil?
+        if slug.to_s.empty? || tracking_number.to_s.empty?
           raise ArgumentError, 'slug and tracking_number are required.'
         end
 
@@ -26,7 +24,7 @@ module AfterShip
 
       # DELETE /trackings/:slug/:tracking_number
       def self.delete(slug, tracking_number, params = {})
-        if slug.empty? || slug.nil? || tracking_number.empty? || tracking_number.nil?
+        if slug.to_s.empty? || tracking_number.to_s.empty?
           raise ArgumentError, 'slug and tracking_number are required.'
         end
 
@@ -35,14 +33,14 @@ module AfterShip
 
       # DELETE /trackings/:id
       def self.delete_by_id(id)
-        raise ArgumentError, 'id is required.' if id.empty? || id.nil?
+        raise ArgumentError, 'id is required.' if id.to_s.empty?
 
         new(:delete, "trackings/#{id}").call
       end
 
       # GET /trackings/:slug/:tracking_number
       def self.get(slug, tracking_number, params = {})
-        if slug.empty? || slug.nil? || tracking_number.empty? || tracking_number.nil?
+        if slug.to_s.empty? || tracking_number.to_s.empty?
           raise ArgumentError, 'slug and tracking_number are required.'
         end
 
@@ -51,7 +49,7 @@ module AfterShip
 
       # GET /trackings/:id
       def self.get_by_id(id, params = {})
-        raise ArgumentError, 'id is required.' if id.empty? || id.nil?
+        raise ArgumentError, 'id is required.' if id.to_s.empty?
 
         new(:get, "trackings/#{id}", params).call
       end
@@ -68,7 +66,7 @@ module AfterShip
 
       # PUT /trackings/:slug/:tracking_number
       def self.update(slug, tracking_number, params = {})
-        if slug.empty? || slug.nil? || tracking_number.empty? || tracking_number.nil?
+        if slug.to_s.empty? || tracking_number.to_s.empty?
           raise ArgumentError, 'slug and tracking_number are required.'
         end
 


### PR DESCRIPTION
I've been experiencing the following error:

```ruby
NoMethodError: undefined method `empty?' for nil:NilClass (NoMethodError)

        if tracking_number.empty? || tracking_number.nil?
```

Aftership gem version: `5.0.0`

### Use cases showcasing the use of the proposed solution

```ruby
irb(main):003:0> nil.empty?
(irb):3:in `<main>': undefined method `empty?' for nil:NilClass (NoMethodError)
irb(main):004:0> ''.empty?
=> true
irb(main):005:0> nil.to_s.empty?
=> true
irb(main):006:0> ''.to_s.empty?
=> true
```